### PR TITLE
Replace strange comma-like quotes

### DIFF
--- a/pages/attend/travel.tbd
+++ b/pages/attend/travel.tbd
@@ -97,10 +97,10 @@ able to use the group code.
 
 ## Driving Directions to Student Center East
 
-**Venue Address**: 750 South Halsted Street – Chicago‚ Illinois 60607
+**Venue Address**: 750 South Halsted Street – Chicago, Illinois 60607
 
-**From the north/O’Hare Airport**: Take the Kennedy Expressway‚ I-90 east.
-Continue on the Kennedy to the Dan Ryan‚ I-90/94 east. Exit at Taylor. Turn
+**From the north/O’Hare Airport**: Take the Kennedy Expressway, I-90 east.
+Continue on the Kennedy to the Dan Ryan, I-90/94 east. Exit at Taylor. Turn
 right (west) and travel one block to the intersection of Taylor and Halsted.
 Turn right (north) onto Halsted and travel one-half block.
 
@@ -137,7 +137,7 @@ stop, located about one block north of the Student Center East.
 walk or cab/Uber/Lyft ride. These trains come in from the suburbs as well.
 Union Station is the nearby train station (estimated distance is 0.6 miles).
 
-For detailed directions using CTA‚ Metra‚ or Pace‚ please visit the
+For detailed directions using CTA, Metra, or Pace, please visit the
 [RTA Chicago website](https://www.rtachicago.org/).
 
 ## Childcare


### PR DESCRIPTION
Found [strange quotes](https://en.wiktionary.org/wiki/%E2%80%9A) in place of commas.
