### PR TITLE
Change camera ready date to August 23

### DIFF
--- a/pages/participate/participate.md
+++ b/pages/participate/participate.md
@@ -45,7 +45,7 @@ Accepted abstracts will be placed on the website ahead of the conference.
 - **BoFs, Workshops, and Tutorials**: Due Friday, April 5. BoF and Workshop notifications Friday, May 10. Tutorial notifications Tuesday, May 21.
 - **Papers and Notebooks**: Due Monday, June 3. Notifications Wednesday, July 10 for notebooks and Wednesday, July 17 for papers.
 - **Posters and Talks**: Due Monday, June 17 AoE. Notifications Friday, July 19.
-- **Camera-ready submissions (Notebooks, Papers)**: Friday, August 9
+- **Camera-ready submissions (Notebooks, Papers)**: Friday, August 23
 
 ## Birds of a Feather (BoFs)
 


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the Committee chairs are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for the Committee chairs
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Camera-ready date set to August 23 since notifications are going out late.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2024-conference-planning-committee) to ask for content reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary
CC @jsubida @KristinaRiemer @mmundt @lmilechin 

